### PR TITLE
feat: Add client-side load balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The minimum supported version of Python is version 3.
 
 ## Configuration
 
-For the client to work it must have knowledge of Bolt's *region* and *url*
+For the client to work it must have knowledge of Bolt's *region* and *url*, as well as preferred *availability zone ID*
 
 The URL must be formatted as follows:
 
@@ -34,12 +34,13 @@ Where the `{region}` within the URL is a string literal placeholder that will be
 export BOLT_URL="<url>"
 ```
 
-**There are two ways to expose Bolt's region to the SDK:**
+**There are two ways to expose Bolt's location to the SDK:**
 
-1. If running on an EC2 instance the SDK will by default use that EC2s region
-2. With the ENV variable: `AWS_REGION`.
+1. If running on an EC2 instance the SDK will by default use that intance's region and zone ID
+2. With the ENV variables: `AWS_REGION` and `AWS_ZONE_ID`.
 ```bash
 export AWS_REGION='<region>'
+export AWS_ZONE_ID='<az-id>'
 ```
 
 ## Debugging

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -10,7 +10,9 @@
 # language governing permissions and limitations under the License.
 
 import json
+from collections import defaultdict
 from os import environ as _environ
+from random import choice
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
 
@@ -19,33 +21,42 @@ from boto3 import Session as _Session
 from botocore.auth import SigV4Auth as _SigV4Auth
 from botocore.awsrequest import AWSRequest as _AWSRequest
 from botocore.config import Config as _Config
+from botocore.exceptions import UnknownEndpointError
 
 
 # Override Session Class
 class Session(_Session):
+    # URL of the quicksilver service discovery endpoint
+    _service_url = None
 
     def client(self, *args, **kwargs):
         if kwargs.get('service_name') == 's3' or 's3' in args:
             kwargs['config'] = self._merge_bolt_config(kwargs.get('config'))
 
             if _environ.get('BOLT_URL') is not None:
-                bolt_url = _environ.get('BOLT_URL')
+                service_url = _environ.get('BOLT_URL')
             else:
                 raise ValueError(
                     'Bolt URL could not be found.\nPlease expose env var BOLT_URL')
 
-            if "{region}" in bolt_url:
-                bolt_url = bolt_url.replace('{region}', self._get_region())
-            # bolt_url = bolt_url.replace('{region}', self._get_region())
+            if "{region}" in service_url:
+                service_url = service_url.replace('{region}', self._get_region())
+                
+            self._service_url = service_url
+            self._availability_zone_id = self._get_availability_zone_id()
+
+            # refresh _bolt_endpoints
+            self._get_bolt_endpoints()
 
             # Use inner function to curry 'creds' and 'bolt_url' into callback
             creds = self.get_credentials().get_frozen_credentials()
 
-            def inject_header(*inject_args, **inject_kwargs):
-
+            def inject_header(*inject_args, **inject_kwargs):                
                 # Modify request URL to redirect to bolt
                 prepared_request = inject_kwargs['request']
-                scheme, host, _, _, _ = urlsplit(bolt_url)
+                # using same scheme as service url for now
+                scheme, _, _, _, _ = urlsplit(service_url)
+                host = self._select_bolt_endpoint(prepared_request.method)
                 _, _, path, query, fragment = urlsplit(prepared_request.url)
                 prepared_request.url = urlunsplit((scheme, host, path, query, fragment))
 
@@ -83,18 +94,50 @@ class Session(_Session):
             return bolt_config
 
     def _get_region(self):
+        region = self.region_name
+        if region is not None:
+            return region
         region = _environ.get('AWS_REGION')
         if region is not None:
             return region
-        else:
-            try:
-                http = urllib3.PoolManager(timeout=3.0)
-                r = http.request('GET', 'http://169.254.169.254/latest/dynamic/instance-identity/document', retries=2)
-                ec2_instance_id = json.loads(r.data.decode('utf-8'))
-                return ec2_instance_id['region']
-            except Exception as e:
-                raise e
+        
+        return self._default_get('http://169.254.169.254/latest/meta-data/placement/region')
 
+
+    def _get_availability_zone_id(self):
+        zone = _environ.get('AWS_ZONE_ID')
+        if zone is not None:
+            return zone
+        
+        return self._default_get('http://169.254.169.254/latest/meta-data/placement/availability-zone-id')
+
+    def _get_bolt_endpoints(self):
+        try:
+            service_url = f'{self._service_url}/services/bolt?az={self._availability_zone_id}'
+            resp = self._default_get(service_url)
+            endpoint_map = json.loads(resp)
+            self._bolt_endpoints = defaultdict(list, endpoint_map)
+        except Exception as e:
+            raise e
+
+    def _select_bolt_endpoint(self, method):
+        read_order = ["main_read_endpoints", "main_write_endpoints", "failover_read_endpoints", "failover_write_endpoints"]
+        write_order = ["main_write_endpoints", "failover_write_endpoints"]
+        preferred_order = read_order if method in {"GET", "HEAD"} else write_order
+        for endpoints in preferred_order:
+            if self._bolt_endpoints[endpoints]:
+                # use random choice for load balancing
+                return choice(self._bolt_endpoints[endpoints])
+        # if we reach this point, no endpoints are available
+        raise UnknownEndpointError(service_name='bolt', region_name=self._get_region())
+
+    def _default_get(url):
+        try:
+            http = urllib3.PoolManager(timeout=3.0)
+            resp = http.request('GET', url, retries=2)
+            return resp.data.decode('utf-8')
+        except Exception as e:
+            raise e
 
 # The default Boto3 session; autoloaded when needed.
 DEFAULT_SESSION = None

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name='bolt-sdk',
     packages=setuptools.find_packages(),
-    version='1.0.2',
+    version='2.0.0',
     description='Bolt Python SDK',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
On client initialization, a service discovery endpoint is called
that returns IPs to connect to Bolt directly, avoiding intermediary
load-balancers for lower latency and network bandwidth costs.