### PR TITLE
feat: refresh bolt endpoints in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,21 @@ An example is:
 
 Where the `{region}` within the URL is a string literal placeholder that will be replaced by the python sdk
 
-**To expose Bolt's URL to the SDK:**
+**There are two  ways to expose Bolt's URL to the SDK:**
 
-1. Declare the ENV variable: `BOLT_URL`
+1. Declare the ENV variables: `BOLT_URL` and `BOLT_HOSTNAME`
 
 ```bash
 export BOLT_URL="<url>"
+export BOLT_HOSTNAME="<url>"
 ```
-
+2. Declare the ENV variable: `BOLT_CUSTOM_DOMAIN`, which constructs Bolt URL and hostname based on default naming
+```bash
+export BOLT_CUSTOM_DOMAIN="example.com"
+```
 **There are two ways to expose Bolt's location to the SDK:**
 
-1. If running on an EC2 instance the SDK will by default use that intance's region and zone ID
+1. If running on an EC2 instance the SDK will by default use that instance's region and zone ID
 2. With the ENV variables: `AWS_REGION` and `AWS_ZONE_ID`.
 ```bash
 export AWS_REGION='<region>'

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -10,11 +10,6 @@
 # language governing permissions and limitations under the License.
 
 import json
-import sched
-import time
-import datetime
-from functools import wraps
-from threading import Thread
 
 from collections import defaultdict
 from os import environ as _environ
@@ -30,89 +25,54 @@ from botocore.awsrequest import AWSRequest as _AWSRequest
 from botocore.config import Config as _Config
 from botocore.exceptions import UnknownEndpointError
 
-
-def async_function(func):
-    @wraps(func)
-    def async_func(*args, **kwargs):
-        func_hl = Thread(daemon=True, target=func, args=args, kwargs=kwargs)
-        func_hl.start()
-
-        return func_hl
-    return async_func
-
-
-def schedule(interval):
-    def decorator(func):
-        def periodic(scheduler, interval, action, actionargs=()):
-            scheduler.enter(interval, 1, periodic,
-                            (scheduler, interval, action, actionargs))
-            action(*actionargs)
-
-        @wraps(func)
-        def wrap(*args, **kwargs):
-            scheduler = sched.scheduler(time.time, time.sleep)
-            periodic(scheduler, interval, func)
-            scheduler.run()
-        return wrap
-    return decorator
+from .bolt_router import BoltRouter, get_region, get_availability_zone_id
 
 # Override Session Class
 class Session(_Session):
-    # URL of the quicksilver service discovery endpoint
-    _service_url = None
-    _mutex = Lock() 
     def __init__(self):
         super(Session, self).__init__()
 
-        if _environ.get('BOLT_URL') is not None:
-            service_url = _environ.get('BOLT_URL')
+        # Load all of the possibly configuration settings
+        region = _environ.get('BOLT_REGION')
+        if region is None:
+            try:
+                region = get_region()
+            except Exception as e:
+                pass
+        custom_domain = _environ.get('BOLT_CUSTOM_DOMAIN')
+        service_url = _environ.get('BOLT_URL')
+        bolt_hostname = _environ.get('BOLT_HOSTNAME')
+
+        if custom_domain is not None and region is not None:
+            scheme = 'https' 
+            service_url = f"quicksilver.{region}.{custom_domain}"
+            hostname = f"bolt.{region}.{custom_domain}"
+        elif service_url is not None and bolt_hostname is not None:
+            hostname = profile['bolt_hostname']
+
+            if "{region}" in hostname:
+                if region is None:
+                    raise ValueError(f'Bolt hostname {hostname} requires region to be specified')
+                hostname = hostname.replace('{region}', region)
+
+            scheme, service_url, _, _, _ = urlsplit(profile['bolt_url'])
+            if "{region}" in service_url:
+                if region is None:
+                    raise ValueError(f'Bolt URL {service_url} requires region to be specified')
+                service_url = service_url.replace('{region}', region)
         else:
+            # must define either `custom_domain` and 'region' or `hostname` + `url`
             raise ValueError(
-                'Bolt URL could not be found.\nPlease expose env var BOLT_URL')
+                'Bolt settings could not be found.\nPlease expose 1. BOLT_URL and BOLT_HOSTNAME or 2. BOLT_CUSTOM_DOMAIN and region')
 
-        if "{region}" in service_url:
-            service_url = service_url.replace('{region}', self._get_region())
-            
-        self._service_url = service_url
-        self._availability_zone_id = self._get_availability_zone_id()
+        az_id = None
+        try:
+            az_id = get_availability_zone_id()
+        except Exception as e:
+            pass
 
-        # refresh _bolt_endpoints
-        self._get_bolt_endpoints()
-
-        @async_function
-        @schedule(30)
-        def update_endpoints():
-            print("updating endpoints", flush=True)
-            self._get_bolt_endpoints()
-
-        update_endpoints()
-
-        # Use inner function to curry 'creds' and 'bolt_url' into callback
-        creds = self.get_credentials().get_frozen_credentials()
-        def inject_header(*inject_args, **inject_kwargs):                
-            # Modify request URL to redirect to bolt
-            prepared_request = inject_kwargs['request']
-            # using same scheme as service url for now
-            scheme, _, _, _, _ = urlsplit(service_url)
-            host = self._select_bolt_endpoint(prepared_request.method)
-            _, _, path, query, fragment = urlsplit(prepared_request.url)
-            prepared_request.url = urlunsplit((scheme, host, path, query, fragment))
-
-            # Sign a get-caller-identity request
-            request = _AWSRequest(
-                method='POST',
-                url='https://sts.amazonaws.com/',
-                data='Action=GetCallerIdentity&Version=2011-06-15',
-                params=None,
-                headers=None
-            )
-            _SigV4Auth(creds, "sts", 'us-east-1').add_auth(request)
-
-            for key in ["X-Amz-Date", "Authorization", "X-Amz-Security-Token"]:
-                if request.headers.get(key):
-                    prepared_request.headers[key] = request.headers[key]
-
-        self.events.register_last('before-send.s3', inject_header)
+        self.bolt_router = BoltRouter(scheme, service_url, hostname, az_id, update_interval=30)
+        self.events.register_last('before-send.s3', self.bolt_router.send)
 
     def client(self, *args, **kwargs):
         if kwargs.get('service_name') == 's3' or 's3' in args:
@@ -133,56 +93,6 @@ class Session(_Session):
             return client_config.merge(bolt_config)
         else:
             return bolt_config
-
-    def _get_region(self):
-        region = self.region_name
-        if region is not None:
-            return region
-        region = _environ.get('AWS_REGION')
-        if region is not None:
-            return region
-        
-        return self._default_get('http://169.254.169.254/latest/meta-data/placement/region')
-
-
-    def _get_availability_zone_id(self):
-        zone = _environ.get('AWS_ZONE_ID')
-        if zone is not None:
-            return zone
-        
-        return self._default_get('http://169.254.169.254/latest/meta-data/placement/availability-zone-id')
-
-    def _get_bolt_endpoints(self):
-        try:
-            service_url = f'{self._service_url}/services/bolt?az={self._availability_zone_id}'
-            resp = self._default_get(service_url)
-            endpoint_map = json.loads(resp)
-            with self._mutex:
-                self._bolt_endpoints = defaultdict(list, endpoint_map)
-        except Exception as e:
-            raise e
-
-    def _select_bolt_endpoint(self, method):
-        read_order = ["main_read_endpoints", "main_write_endpoints", "failover_read_endpoints", "failover_write_endpoints"]
-        write_order = ["main_write_endpoints", "failover_write_endpoints"]
-        preferred_order = read_order if method in {"GET", "HEAD"} else write_order
-
-        with self._mutex:
-            for endpoints in preferred_order:
-                if self._bolt_endpoints[endpoints]:
-                    # use random choice for load balancing
-                    return choice(self._bolt_endpoints[endpoints])
-
-        # if we reach this point, no endpoints are available
-        raise UnknownEndpointError(service_name='bolt', region_name=self._get_region())
-
-    def _default_get(self, url):
-        try:
-            http = urllib3.PoolManager(timeout=3.0)
-            resp = http.request('GET', url, retries=2)
-            return resp.data.decode('utf-8')
-        except Exception as e:
-            raise e
 
 # The default Boto3 session; autoloaded when needed.
 DEFAULT_SESSION = None

--- a/bolt/bolt_router.py
+++ b/bolt/bolt_router.py
@@ -1,0 +1,177 @@
+from collections import defaultdict
+import json
+from os import environ
+from random import choice
+from urllib.parse import urlsplit, urlunsplit
+from urllib3 import PoolManager
+from threading import Lock
+
+import sys 
+import sched
+import time
+from functools import wraps
+from threading import Thread
+
+
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.exceptions import UnknownEndpointError
+from botocore.session import get_session
+from botocore.httpsession import URLLib3Session
+
+# throws Exception if not found
+def get_region():
+    region = environ.get('AWS_REGION')
+    if region is not None:
+        return region
+    
+    return _default_get('http://169.254.169.254/latest/meta-data/placement/region')
+
+# throws Exception if not found
+def get_availability_zone_id():
+    zone = environ.get('AWS_ZONE_ID')
+    if zone is not None:
+        return zone
+    
+    return _default_get('http://169.254.169.254/latest/meta-data/placement/availability-zone-id')
+
+
+def _default_get(url):
+    try:
+        http = PoolManager(timeout=3.0)
+        resp = http.request('GET', url, retries=2)
+        return resp.data.decode('utf-8')
+    except Exception as e:
+        raise e
+
+
+def async_function(func):
+    @wraps(func)
+    def async_func(*args, **kwargs):
+        func_hl = Thread(daemon=True, target=func, args=args, kwargs=kwargs)
+        func_hl.start()
+
+        return func_hl
+    return async_func
+
+
+def schedule(interval):
+    def decorator(func):
+        def periodic(scheduler, interval, action, actionargs=()):
+            scheduler.enter(interval, 1, periodic,
+                            (scheduler, interval, action, actionargs))
+            action(*actionargs)
+
+        @wraps(func)
+        def wrap(*args, **kwargs):
+            scheduler = sched.scheduler(time.time, time.sleep)
+            periodic(scheduler, interval, func)
+            scheduler.run()
+        return wrap
+    return decorator
+
+class BoltSession(URLLib3Session):
+    """
+    We need to override the default behavior of the URLLib3Session class to accept a different hostname for SSL verification,
+    since we want to connect to a specific IP without relying on DNS. See https://urllib3.readthedocs.io/en/latest/advanced-usage.html#custom-sni-hostname
+    """
+    def __init__(self, bolt_hostname, **kwargs):
+        self._bolt_hostname = bolt_hostname
+        super().__init__(**kwargs)
+
+
+    def _get_pool_manager_kwargs(self, **extra_kwargs):
+        # Add 'server_hostname' arg to use for SSL validation
+        extra_kwargs.update(server_hostname=self._bolt_hostname)
+        return super()._get_pool_manager_kwargs(**extra_kwargs)
+
+
+    def send(self, request):
+        request.headers['Host'] = self._bolt_hostname
+        return super().send(request)
+            
+class BoltRouter:
+    """A stateful request mutator for Bolt S3 proxy.
+
+    Sends S3 requests to an alternative Bolt URL based on configuration.
+
+    To set a Bolt S3 proxy URL, run `aws [--profile PROFILE] configure set bolt.url http://localhost:9000`.
+    """
+
+    # const ordering to use when selecting endpoints
+    PREFERRED_READ_ENDPOINT_ORDER = ("main_read_endpoints", "main_write_endpoints", "failover_read_endpoints", "failover_write_endpoints")
+    PREFERRED_WRITE_ENDPOINT_ORDER = ("main_write_endpoints", "failover_write_endpoints")
+
+    def __init__(self, scheme, service_url, hostname, az_id, update_interval=-1):
+        # The scheme (parsed at bootstrap from the AWS config).
+        self._scheme = scheme
+        # The service discovery host (parsed at bootstrap from the AWS config).
+        self._service_url = service_url
+        # the hostname to use for SSL validation when connecting directly to Bolt IPs
+        self._hostname = hostname
+        # Availability zone ID to use (may be none)
+        self._az_id = az_id
+
+        # Map of Bolt endpoints to use for connections, and mutex protecting it
+        self._bolt_endpoints = defaultdict(list)
+        self._mutex = Lock()
+
+        self._get_endpoints()
+
+        if update_interval > 0:
+            @async_function
+            @schedule(update_interval)
+            def update_endpoints():
+                try: 
+                    self._get_endpoints()
+                except Exception as e:
+                    print(e, file=sys.stderr, flush=True)
+            update_endpoints()
+
+    def send(self, *args, **kwargs):
+        # Dispatches to the configured Bolt scheme and host.
+        prepared_request = kwargs['request']
+        _, _, path, query, fragment = urlsplit(prepared_request.url)
+        host = self._select_endpoint(prepared_request.method)
+
+        prepared_request.url = urlunsplit((self._scheme, host, path, query, fragment))
+
+        request = AWSRequest(
+          method='POST',
+          url='https://sts.amazonaws.com/',
+          data='Action=GetCallerIdentity&Version=2011-06-15',
+          params=None,
+          headers=None
+        )
+        SigV4Auth(get_session().get_credentials().get_frozen_credentials(), "sts", 'us-east-1').add_auth(request)
+
+        for key in ["X-Amz-Date", "Authorization", "X-Amz-Security-Token"]:
+          if request.headers.get(key):
+            prepared_request.headers[key] = request.headers[key]
+        
+        # send this request with our custom session options
+        # if an AWSResponse is returned directly from a `before-send` event handler function, 
+        # botocore will use that as the response without making its own request.
+        return BoltSession(self._hostname).send(prepared_request)
+
+    def _get_endpoints(self):
+        try:
+            service_url = f'{self._service_url}/services/bolt?az={self._az_id}'
+            resp = _default_get(service_url)
+            endpoint_map = json.loads(resp)
+            with self._mutex: 
+                self._bolt_endpoints = defaultdict(list, endpoint_map)
+        except Exception as e:
+            raise e
+
+    def _select_endpoint(self, method):
+        preferred_order = self.PREFERRED_READ_ENDPOINT_ORDER if method in {"GET", "HEAD"} else self.PREFERRED_WRITE_ENDPOINT_ORDER
+        
+        with self._mutex: 
+            for endpoints in preferred_order:
+                if self._bolt_endpoints[endpoints]:
+                    # use random choice for load balancing
+                    return choice(self._bolt_endpoints[endpoints])
+        # if we reach this point, no endpoints are available
+        raise UnknownEndpointError(service_name='bolt', region_name=self._az_id)
+

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name='bolt-sdk',
     packages=setuptools.find_packages(),
-    version='2.0.0',
+    version='2.0.1',
     description='Bolt Python SDK',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,6 +10,7 @@ def client_tests():
     lboto = s3_boto.list_buckets()
     lbolt = s3_bolt.list_buckets()
 
+    print(lbolt)
     assert (lboto != lbolt)
 
     # Test that other services remain un-affected
@@ -31,8 +32,8 @@ def test_refresh():
 
 def session_tests():
     # Test signing for s3
-    session_boto = boto3.Session(profile_name='nobolt')
-    session_bolt = bolt3.Session(profile_name='nobolt')
+    session_boto = boto3.Session()
+    session_bolt = bolt3.Session()
 
     s3_boto = session_boto.client('s3')
     s3_bolt = session_bolt.client('s3')
@@ -40,6 +41,7 @@ def session_tests():
     lboto = s3_boto.list_buckets()
     lbolt = s3_bolt.list_buckets()
 
+    print(lbolt)
     assert (lboto != lbolt)
 
     # Test that other services remain un-affected


### PR DESCRIPTION
Refresh bolt endpoints in background with daemon thread.
Also fixed an issue with get_default being called as an instance method even though it wasn't one.

Overall, this looks like it could be problematic because state is stored at session level, but it seems like it should be at client level? Probably need to do a refactor to address that. 