### PR TITLE
build: fix twine pypi upload

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,4 +21,4 @@ package:
     - python3 setup.py sdist bdist_wheel
     - twine check dist/*
     - echo -e "[distutils]\nindex-servers = pypi\n\n[pypi]\nusername = __token__\npassword = ${PYPI_API_TOKEN}\n" >> ~/.pypirc
-    - python3 -m twine --verbose upload dist/*
+    - python3 -m twine upload --verbose dist/*


### PR DESCRIPTION
Verbose flag was in the wrong place