### PR TITLE
feat: s3 failovers, readme improvements, read endpoint fetch improvements, metadata api fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,6 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-
 name: Upload Python Package
 on:
   release:
@@ -20,9 +19,9 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -14,24 +14,36 @@ The minimum supported version of Python is version 3.
 python3 -m pip install granica-sdk
 ```
 
-## Configuration
+## Usage
 
-For the client to work it must have knowledge of Granica's *service discovery url*.
-These are parameterized by the *region* of Granica's deployment. A preferred *availability zone ID* can also be provided for AZ-aware routing.
+In order to use this package, you need to set the following environment variables where your application will be running
 
-**Configure the Granica custom domain:**
-Declare the ENV variable: `GRANICA_CUSTOM_DOMAIN`, which constructs Granica URL and hostname based on default naming, and AWS region.
 ```bash
-export GRANICA_CUSTOM_DOMAIN="example.com"
+export GRANICA_CUSTOM_DOMAIN=<YOUR_CUSTOM_DOMAIN>
+export GRANICA_REGION=<YOUR_GRANICA_CLUSTER_REGION>
+# Optional if not running on an ec2 instance to force read from a read-replica in this az
+export GRANICA_AZ_ID=<AZ_ID>
 ```
 
-**There are two ways to expose Granica's region/preferred availability zone to the SDK:**
+For backwards compatibility, the following environment variables are supported
 
-1. If running on an EC2 instance the SDK will by default use that instance's region and zone ID
-2. With the ENV variables: `AWS_REGION` and `AWS_ZONE_ID`.
-```bash
-export AWS_REGION='<region>'
-export AWS_ZONE_ID='<az-id>'
+```
+BOLT_CUSTOM_DOMAIN --> GRANICA_CUSTOM_DOMAIN
+BOLT_REGION --> GRANICA_REGION
+BOLT_AZ_ID --> GRANICA_AZ_ID
+```
+
+If the region and AZ environment variables aren't specified when running on an EC2 instance, the SDK will use the ec2 metadata api to fetch the instance's region and availability zone id.
+
+## Example S3 GetObject
+
+```python
+import granica as boto3
+
+s3_client = boto3.client('s3')
+s3_client.put_object(Body="data", Bucket="BUCKET_NAME", Key="key")
+response = s3_client.get_object(Bucket="BUCKET_NAME", Key="key")
+obj = response['Body'].read()
 ```
 
 ## Debugging
@@ -40,19 +52,10 @@ Import the default logger and set its level to DEBUG
 
 `logging.getLogger().setLevel(logging.DEBUG)`
 
-## Example S3 GetObject
-
-```python
-import granica as boto3
-
-s3_client = boto3.client('s3')
-response = s3_client.get_object(Bucket='MyBucket', Key='MyKey.csv')
-obj = response['Body'].read()
-
-```
-
 ## Tests
+
 Basic integration tests are provided for the modified Session/Client interfaces. They must be run in an environment with a properly configured Granica deployment accessible.
+
 ```bash
 python3 tests/tests.py
 ```

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -41,7 +41,7 @@ class Session(Boto3Session):
                     region = get_region()
                 except Exception as e:
                     raise ValueError(
-                        "GRANICA_REGION, BOLT_REGION environment variables are not set, and could not be fetched from ec2 metadata api."
+                        "GRANICA_REGION and BOLT_REGION environment variables are not set; region could not be fetched from ec2 metadata api."
                     )
 
         service_url = environ.get("BOLT_URL")

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -27,15 +27,17 @@ class Session(Boto3Session):
         super(Session, self).__init__()
 
         # Load all of the possibly configuration settings
-        region = environ.get("BOLT_REGION")
+        region = environ.get("GRANICA_REGION")
         if region is None:
-            try:
-                region = get_region()
-            except Exception as e:
-                print(
-                    "BOLT_REGION environment variable is not set, and could not be automatically determined."
-                )
-                sys.exit(1)
+            region = environ.get("BOLT_REGION")
+            if region is None:
+                try:
+                    region = get_region()
+                except Exception as e:
+                    print(
+                        "BOLT_REGION environment variable is not set, and could not be automatically determined."
+                    )
+                    sys.exit(1)
         custom_domain = environ.get("GRANICA_CUSTOM_DOMAIN")
         if custom_domain is None:
             custom_domain = environ.get("BOLT_CUSTOM_DOMAIN")
@@ -60,15 +62,17 @@ class Session(Boto3Session):
                 "Granica settings could not be found.\nPlease expose GRANICA_CUSTOM_DOMAIN"
             )
 
-        az_id = environ.get("BOLT_AZ_ID")
+        az_id = environ.get("GRANICA_AZ_ID")
         if az_id is None:
-            try:
-                az_id = get_availability_zone_id()
-            except Exception as e:
-                print(
-                    "BOLT_AZ_ID environment variable is not set, and could not be automatically determined."
-                )
-                pass
+            az_id = environ.get("BOLT_AZ_ID")
+            if az_id is None:
+                try:
+                    az_id = get_availability_zone_id()
+                except Exception as e:
+                    print(
+                        "BOLT_AZ_ID environment variable is not set, and could not be automatically determined."
+                    )
+                    pass
 
         self.bolt_router = BoltRouter(
             scheme=scheme,

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -9,86 +9,95 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import json
-
-from collections import defaultdict
-from os import environ as _environ
-from random import choice
-from threading import Lock 
+import sys
+from os import environ
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
 
-import urllib3
-from boto3 import Session as _Session
-from botocore.auth import SigV4Auth as _SigV4Auth
-from botocore.awsrequest import AWSRequest as _AWSRequest
-from botocore.config import Config as _Config
-from botocore.exceptions import UnknownEndpointError
+from boto3 import Session as Boto3Session
+from botocore.config import Config as BotoCoreConfig
 
 from .bolt_router import BoltRouter, get_region, get_availability_zone_id
 
+BOLT_ENDPOINT_UPDATE_INTERVAL = 10
+
+
 # Override Session Class
-class Session(_Session):
+class Session(Boto3Session):
     def __init__(self):
         super(Session, self).__init__()
 
         # Load all of the possibly configuration settings
-        region = _environ.get('BOLT_REGION')
+        region = environ.get("BOLT_REGION")
         if region is None:
             try:
                 region = get_region()
             except Exception as e:
+                print(
+                    "BOLT_REGION environment variable is not set, and could not be automatically determined."
+                )
                 pass
-        custom_domain = _environ.get('GRANICA_CUSTOM_DOMAIN')
+        custom_domain = environ.get("GRANICA_CUSTOM_DOMAIN")
         if custom_domain is None:
-            custom_domain = _environ.get('BOLT_CUSTOM_DOMAIN')
-        service_url = _environ.get('BOLT_URL')
-        bolt_hostname = _environ.get('BOLT_HOSTNAME')
+            custom_domain = environ.get("BOLT_CUSTOM_DOMAIN")
+        service_url = environ.get("BOLT_URL")
         hostname = None
 
         if custom_domain is not None and region is not None:
-            scheme = 'https' 
-            service_url = f"quicksilver.{region}.{custom_domain}"
+            scheme = "https"
+            service_url = "{}://quicksilver.{}.{}".format(scheme, region, custom_domain)
             hostname = f"bolt.{region}.{custom_domain}"
         elif service_url is not None:
             scheme, service_url, _, _, _ = urlsplit(service_url)
             if "{region}" in service_url:
                 if region is None:
-                    raise ValueError(f'Granica URL {service_url} requires region to be specified')
-                service_url = service_url.replace('{region}', region)
+                    raise ValueError(
+                        f"Granica URL {service_url} requires region to be specified"
+                    )
+                service_url = service_url.replace("{region}", region)
         else:
             # must define either `custom_domain` or `url`
             raise ValueError(
-                'Granica settings could not be found.\nPlease expose GRANICA_CUSTOM_DOMAIN')
+                "Granica settings could not be found.\nPlease expose GRANICA_CUSTOM_DOMAIN"
+            )
 
-        az_id = None
-        try:
-            az_id = get_availability_zone_id()
-        except Exception as e:
-            pass
+        az_id = environ.get("BOLT_AZ_ID")
+        if az_id is None:
+            try:
+                az_id = get_availability_zone_id()
+            except Exception as e:
+                print(
+                    "BOLT_AZ_ID environment variable is not set, and could not be automatically determined."
+                )
+                pass
 
-        self.bolt_router = BoltRouter(scheme, service_url, hostname, region, az_id, update_interval=30)
-        self.events.register_last('before-send.s3', self.bolt_router.send)
+        self.bolt_router = BoltRouter(
+            scheme=scheme,
+            quicksilver_api_base_url=service_url,
+            hostname=hostname,
+            region=region,
+            az_id=az_id,
+            update_interval=BOLT_ENDPOINT_UPDATE_INTERVAL,
+        )
+        self.events.register_last("before-send.s3", self.bolt_router.send)
 
     def client(self, *args, **kwargs):
-        if kwargs.get('service_name') == 's3' or 's3' in args:
-            kwargs['config'] = self._merge_bolt_config(kwargs.get('config'))
+        if kwargs.get("service_name") == "s3" or "s3" in args:
+            kwargs["config"] = self._merge_bolt_config(kwargs.get("config"))
             return self._session.create_client(*args, **kwargs)
         else:
             return self._session.create_client(*args, **kwargs)
 
-    def _merge_bolt_config(self, client_config) :
+    def _merge_bolt_config(self, client_config):
         # Override client config
-        bolt_config = _Config(
-            s3={
-                'addressing_style': 'path',
-                'signature_version': 's3v4'
-            }
+        bolt_config = BotoCoreConfig(
+            s3={"addressing_style": "path", "signature_version": "s3v4"}
         )
         if client_config is not None:
             return client_config.merge(bolt_config)
         else:
             return bolt_config
+
 
 # The default Boto3 session; autoloaded when needed.
 DEFAULT_SESSION = None
@@ -133,5 +142,3 @@ def resource(*args, **kwargs):
     See :py:meth:`boto3.session.Session.resource`.
     """
     return _get_default_session().resource(*args, **kwargs)
-
-

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -12,12 +12,11 @@
 import sys
 from os import environ
 from urllib.parse import urlsplit
-from urllib.parse import urlunsplit
 
 from boto3 import Session as Boto3Session
 from botocore.config import Config as BotoCoreConfig
 
-from .bolt_router import BoltRouter, get_region, get_availability_zone_id
+from .bolt_router import BoltRouter, get_availability_zone_id, get_region
 
 BOLT_ENDPOINT_UPDATE_INTERVAL = 10
 

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -35,7 +35,7 @@ class Session(Boto3Session):
                 print(
                     "BOLT_REGION environment variable is not set, and could not be automatically determined."
                 )
-                pass
+                sys.exit(1)
         custom_domain = environ.get("GRANICA_CUSTOM_DOMAIN")
         if custom_domain is None:
             custom_domain = environ.get("BOLT_CUSTOM_DOMAIN")

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -9,7 +9,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import sys
 from os import environ
 from urllib.parse import urlsplit
 
@@ -30,10 +29,9 @@ class Session(Boto3Session):
         if custom_domain is None:
             custom_domain = environ.get("BOLT_CUSTOM_DOMAIN")
             if custom_domain is None:
-                print(
+                raise ValueError(
                     "One of GRANICA_CUSTOM_DOMAIN, BOLT_CUSTOM_DOMAIN environment variables must be set."
                 )
-                sys.exit(1)
 
         region = environ.get("GRANICA_REGION")
         if region is None:
@@ -42,10 +40,9 @@ class Session(Boto3Session):
                 try:
                     region = get_region()
                 except Exception as e:
-                    print(
+                    raise ValueError(
                         "GRANICA_REGION, BOLT_REGION environment variables are not set, and could not be fetched from ec2 metadata api."
                     )
-                    sys.exit(1)
 
         service_url = environ.get("BOLT_URL")
         hostname = None

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -35,7 +35,7 @@ class Session(Boto3Session):
                     region = get_region()
                 except Exception as e:
                     print(
-                        "BOLT_REGION environment variable is not set, and could not be automatically determined."
+                        "GRANICA_REGION, BOLT_REGION environment variables are not set, and could not be fetched from ec2 metadata api."
                     )
                     sys.exit(1)
         custom_domain = environ.get("GRANICA_CUSTOM_DOMAIN")

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -26,7 +26,15 @@ class Session(Boto3Session):
     def __init__(self):
         super(Session, self).__init__()
 
-        # Load all of the possibly configuration settings
+        custom_domain = environ.get("GRANICA_CUSTOM_DOMAIN")
+        if custom_domain is None:
+            custom_domain = environ.get("BOLT_CUSTOM_DOMAIN")
+            if custom_domain is None:
+                print(
+                    "One of GRANICA_CUSTOM_DOMAIN, BOLT_CUSTOM_DOMAIN environment variables must be set."
+                )
+                sys.exit(1)
+
         region = environ.get("GRANICA_REGION")
         if region is None:
             region = environ.get("BOLT_REGION")
@@ -38,9 +46,7 @@ class Session(Boto3Session):
                         "GRANICA_REGION, BOLT_REGION environment variables are not set, and could not be fetched from ec2 metadata api."
                     )
                     sys.exit(1)
-        custom_domain = environ.get("GRANICA_CUSTOM_DOMAIN")
-        if custom_domain is None:
-            custom_domain = environ.get("BOLT_CUSTOM_DOMAIN")
+
         service_url = environ.get("BOLT_URL")
         hostname = None
 

--- a/granica/bolt_router.py
+++ b/granica/bolt_router.py
@@ -4,10 +4,12 @@ from os import environ
 from random import choice
 from urllib.parse import urlsplit, urlunsplit
 from urllib3 import PoolManager
+from urllib3.util.retry import Retry
 from threading import Lock
 
+import copy
 import random
-import sys 
+import sys
 import sched
 import time
 import datetime
@@ -18,34 +20,72 @@ from threading import Thread
 
 from botocore.auth import SigV4Auth, SIGV4_TIMESTAMP, logger
 from botocore.awsrequest import AWSRequest
-from botocore.exceptions import UnknownEndpointError
+from botocore.exceptions import UnknownEndpointError, NoCredentialsError
 from botocore.session import get_session
 from botocore.httpsession import URLLib3Session
 
-# throws Exception if not found
+EC2_INSTANCE_METADATA_API_BASE_URL = "http://169.254.169.254"
+
+http_pool = PoolManager(
+    retries=Retry(
+        total=5,  # Total number of retries
+        backoff_factor=0.1,  # Time to sleep between retries (0.1s, 0.2s, 0.4s, ...)
+    )
+)
+
+
+def get_metadata_api_token():
+    url = "{}/latest/api/token".format(EC2_INSTANCE_METADATA_API_BASE_URL)
+    headers = {"X-aws-ec2-metadata-token-ttl-seconds": "21600"}
+    response = http_pool.request("PUT", url, headers=headers)
+    if response.status == 200:
+        token = response.data.decode("utf-8")
+        return token
+    else:
+        raise Exception(
+            "Failed to fetch token. Status code: {}".format(response.status)
+        )
+
+
+# throws Exception on failure
 def get_region():
-    region = environ.get('AWS_REGION')
+    region = environ.get("AWS_REGION")
     if region is not None:
         return region
-    
-    return _default_get('http://169.254.169.254/latest/meta-data/placement/region')
+    token = get_metadata_api_token()
+    headers = {"X-aws-ec2-metadata-token": token}
+    url = "{}/latest/meta-data/placement/region".format(
+        EC2_INSTANCE_METADATA_API_BASE_URL
+    )
+    response = http_pool.request("GET", url, headers=headers)
+    if response.status == 200:
+        return response.data.decode("utf-8")
+    else:
+        raise Exception(
+            "Failed to fetch region. Status code: {}".format(response.status)
+        )
+
 
 # throws Exception if not found
 def get_availability_zone_id():
-    zone = environ.get('AWS_ZONE_ID')
+    zone = environ.get("AWS_ZONE_ID")
     if zone is not None:
         return zone
-    
-    return _default_get('http://169.254.169.254/latest/meta-data/placement/availability-zone-id')
 
-
-def _default_get(url):
-    try:
-        http = PoolManager(timeout=3.0)
-        resp = http.request('GET', url, retries=2)
-        return resp.data.decode('utf-8')
-    except Exception as e:
-        raise e
+    token = get_metadata_api_token()
+    headers = {"X-aws-ec2-metadata-token": token}
+    url = "{}/latest/meta-data/placement/availability-zone-id".format(
+        EC2_INSTANCE_METADATA_API_BASE_URL
+    )
+    response = http_pool.request("GET", url, headers=headers)
+    if response.status == 200:
+        return response.data.decode("utf-8")
+    else:
+        raise Exception(
+            "Failed to fetch availability zone id. Status code: {}".format(
+                response.status
+            )
+        )
 
 
 def async_function(func):
@@ -53,16 +93,17 @@ def async_function(func):
     def async_func(*args, **kwargs):
         func_hl = Thread(daemon=True, target=func, args=args, kwargs=kwargs)
         func_hl.start()
-
         return func_hl
+
     return async_func
 
 
 def schedule(interval):
     def decorator(func):
         def periodic(scheduler, interval, action, actionargs=()):
-            scheduler.enter(interval, 1, periodic,
-                            (scheduler, interval, action, actionargs))
+            scheduler.enter(
+                interval, 1, periodic, (scheduler, interval, action, actionargs)
+            )
             action(*actionargs)
 
         @wraps(func)
@@ -70,27 +111,29 @@ def schedule(interval):
             scheduler = sched.scheduler(time.time, time.sleep)
             periodic(scheduler, interval, func)
             scheduler.run()
+
         return wrap
+
     return decorator
+
 
 class BoltSession(URLLib3Session):
     """
     We need to override the default behavior of the URLLib3Session class to accept a different hostname for SSL verification,
     since we want to connect to a specific IP without relying on DNS. See https://urllib3.readthedocs.io/en/latest/advanced-usage.html#custom-sni-hostname
     """
+
     def __init__(self, bolt_hostname, **kwargs):
         self._bolt_hostname = bolt_hostname
         super().__init__(**kwargs)
-
 
     def _get_pool_manager_kwargs(self, **extra_kwargs):
         # Add 'server_hostname' arg to use for SSL validation
         extra_kwargs.update(server_hostname=self._bolt_hostname)
         return super()._get_pool_manager_kwargs(**extra_kwargs)
 
-
     def send(self, request):
-        request.headers['Host'] = self._bolt_hostname
+        request.headers["Host"] = self._bolt_hostname
         for key in request.headers.keys():
             if key == "Expect":
                 continue
@@ -105,17 +148,28 @@ def roundTime(dt=None, dateDelta=datetime.timedelta(minutes=1)):
     """
     roundTo = dateDelta.total_seconds()
 
-    if dt == None : dt = datetime.datetime.now()
+    if dt == None:
+        dt = datetime.datetime.now()
     seconds = (dt - dt.min).seconds
     # // is a floor division, not a comment on following line:
-    rounding = (seconds+roundTo/2) // roundTo * roundTo
-    return dt + datetime.timedelta(0,rounding-seconds,-dt.microsecond)
+    rounding = (seconds + roundTo / 2) // roundTo * roundTo
+    return dt + datetime.timedelta(0, rounding - seconds, -dt.microsecond)
+
 
 class BoltSigV4Auth(SigV4Auth):
-    def __init__(self, *args, bolt_timestamp_pin_duration = datetime.timedelta(minutes=10), **kwargs):
+    def __init__(
+        self,
+        *args,
+        bolt_timestamp_pin_duration=datetime.timedelta(minutes=10),
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self.__bolt_timestamp_pin_duration = bolt_timestamp_pin_duration
-        self.__bolt_random_offset = datetime.timedelta(seconds=random.randint(0, self.__bolt_timestamp_pin_duration.total_seconds()))
+        self.__bolt_random_offset = datetime.timedelta(
+            seconds=random.randint(
+                0, self.__bolt_timestamp_pin_duration.total_seconds()
+            )
+        )
 
     # From https://github.com/boto/botocore/blob/e720eefba94963f373b3ff7c888a89bea06cd4a1/botocore/auth.py
     def add_auth(self, request):
@@ -125,19 +179,25 @@ class BoltSigV4Auth(SigV4Auth):
 
         # Sign with a fixed time so that auth header can be cached
         # This fixed time is offset by a random interval to smooth out refreshes across clients
-        datetime_now = roundTime(datetime.datetime.utcnow() - self.__bolt_random_offset, self.__bolt_timestamp_pin_duration) + self.__bolt_random_offset
+        datetime_now = (
+            roundTime(
+                datetime.datetime.utcnow() - self.__bolt_random_offset,
+                self.__bolt_timestamp_pin_duration,
+            )
+            + self.__bolt_random_offset
+        )
 
-        request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
+        request.context["timestamp"] = datetime_now.strftime(SIGV4_TIMESTAMP)
         # This could be a retry.  Make sure the previous
         # authorization header is removed first.
         self._modify_request_before_signing(request)
         canonical_request = self.canonical_request(request)
         logger.debug("Calculating signature using v4 auth.")
-        logger.debug('CanonicalRequest:\n%s', canonical_request)
+        logger.debug("CanonicalRequest:\n%s", canonical_request)
         string_to_sign = self.string_to_sign(request, canonical_request)
-        logger.debug('StringToSign:\n%s', string_to_sign)
+        logger.debug("StringToSign:\n%s", string_to_sign)
         signature = self.signature(string_to_sign, request)
-        logger.debug('Signature:\n%s', signature)
+        logger.debug("Signature:\n%s", signature)
 
         self._inject_signature_to_request(request, signature)
 
@@ -151,19 +211,45 @@ class BoltRouter:
     """
 
     # const ordering to use when selecting endpoints
-    PREFERRED_READ_ENDPOINT_ORDER = ("main_read_endpoints", "main_write_endpoints", "failover_read_endpoints", "failover_write_endpoints")
-    PREFERRED_WRITE_ENDPOINT_ORDER = ("main_write_endpoints", "failover_write_endpoints")
+    PREFERRED_READ_ENDPOINT_ORDER = (
+        "main_read_endpoints",
+        "main_write_endpoints",
+        "failover_read_endpoints",
+        "failover_write_endpoints",
+    )
+    PREFERRED_WRITE_ENDPOINT_ORDER = (
+        "main_write_endpoints",
+        "failover_write_endpoints",
+    )
 
-    def __init__(self, scheme, service_url, hostname, region, az_id, update_interval=-1):
+    def __init__(
+        self,
+        scheme,
+        quicksilver_api_base_url,
+        hostname,
+        region,
+        az_id,
+        update_interval=-1,
+    ):
         # The scheme (parsed at bootstrap from the AWS config).
         self._scheme = scheme
         # The service discovery host (parsed at bootstrap from the AWS config).
-        self._service_url = service_url
+        self._quicksilver_api_base_url = quicksilver_api_base_url
         # the hostname to use for SSL validation when connecting directly to Bolt IPs
         self._hostname = hostname
         # Availability zone ID to use (may be none)
         self._az_id = az_id
         self._region = region
+
+        if self._az_id is None:
+            # None obj formats as "None" into the string so let's not include it if it's None
+            self._quicksilver_url = "{}/services/bolt".format(
+                self._quicksilver_api_base_url
+            )
+        else:
+            self._quicksilver_url = "{}/services/bolt?az={}".format(
+                self._quicksilver_api_base_url, self._az_id
+            )
 
         # Map of Bolt endpoints to use for connections, and mutex protecting it
         self._bolt_endpoints = defaultdict(list)
@@ -171,77 +257,116 @@ class BoltRouter:
 
         self._get_endpoints()
 
-        self._auth = BoltSigV4Auth(get_session().get_credentials().get_frozen_credentials(), "s3", region)
+        self._auth = BoltSigV4Auth(
+            get_session().get_credentials().get_frozen_credentials(), "s3", region
+        )
         # Each client uses a random 4-char long prefix to randomize the S3 path used for auth lookups
-        self._prefix = ''.join(random.choice(string.ascii_uppercase  + string.ascii_lowercase + string.digits) for _ in range(4))
+        self._prefix = "".join(
+            random.choice(
+                string.ascii_uppercase + string.ascii_lowercase + string.digits
+            )
+            for _ in range(4)
+        )
 
         if update_interval > 0:
+
             @async_function
             @schedule(update_interval)
             def update_endpoints():
-                try: 
+                try:
                     self._get_endpoints()
                 except Exception as e:
                     print(e, file=sys.stderr, flush=True)
+
             update_endpoints()
 
     def send(self, *args, **kwargs):
         # Dispatches to the configured Bolt scheme and host.
-        prepared_request = kwargs['request']
+        prepared_request = kwargs["request"]
+        incoming_request = copy.deepcopy(prepared_request)
         _, _, path, query, fragment = urlsplit(prepared_request.url)
         host = self._select_endpoint(prepared_request.method)
         if self._scheme == "http":
-            host = host+":9000"
+            host = host + ":9000"
 
         prepared_request.url = urlunsplit((self._scheme, host, path, query, fragment))
 
         # TODO Fix handling requests without bucket names (like list)
-        source_bucket = path.split('/')[1]
+        source_bucket = path.split("/")[1]
 
         # Construct the HEAD request that would be sent out by Bolt for authentication
         request = AWSRequest(
-          method='HEAD',
-          url='https://s3.{}.amazonaws.com/{}/{}/auth'.format(self._region,source_bucket, self._prefix),
-          data=None,
-          params=None,
-          headers=None
+            method="HEAD",
+            url="https://s3.{}.amazonaws.com/{}/{}/auth".format(
+                self._region, source_bucket, self._prefix
+            ),
+            data=None,
+            params=None,
+            headers=None,
         )
         # S3 requests always need the Content-SHA header included in the signature. As the HEAD request has no
         # content, it's just the SHA of an empty string and it's always the value below.
         # https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
-        request.headers['X-Amz-Content-Sha256'] = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-
+        request.headers[
+            "X-Amz-Content-Sha256"
+        ] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
         self._auth.add_auth(request)
 
-        for key in ["X-Amz-Date", "Authorization", "X-Amz-Security-Token", "X-Amz-Content-Sha256"]:
-          if request.headers.get(key):
-            prepared_request.headers[key] = request.headers[key]
-        prepared_request.headers['X-Bolt-Auth-Prefix'] = self._prefix
+        for key in [
+            "X-Amz-Date",
+            "Authorization",
+            "X-Amz-Security-Token",
+            "X-Amz-Content-Sha256",
+        ]:
+            if request.headers.get(key):
+                prepared_request.headers[key] = request.headers[key]
+        prepared_request.headers["X-Bolt-Auth-Prefix"] = self._prefix
+
+        try:
+            bolt_response = BoltSession(self._hostname).send(prepared_request)
+
+            if 400 <= bolt_response.status_code < 500:
+                logger.debug(
+                    "bolt request failed - 4xx - falling back to aws",
+                    extra={"status_code": bolt_response.status_code},
+                )
+                return URLLib3Session().send(incoming_request)
+            return bolt_response
+        except Exception as e:
+            logger.debug(
+                "bolt request failed - exception - falling back to aws",
+                extra={"exception": e},
+            )
+            return URLLib3Session().send(incoming_request)
 
         # send this request with our custom session options
-        # if an AWSResponse is returned directly from a `before-send` event handler function, 
+        # if an AWSResponse is returned directly from a `before-send` event handler function,
         # botocore will use that as the response without making its own request.
         return BoltSession(self._hostname).send(prepared_request)
 
     def _get_endpoints(self):
         try:
-            service_url = f'{self._service_url}/services/bolt?az={self._az_id}'
-            resp = _default_get(service_url)
-            endpoint_map = json.loads(resp)
-            with self._mutex: 
-                self._bolt_endpoints = defaultdict(list, endpoint_map)
+            response = http_pool.request("GET", self._quicksilver_url)
+            if response.status == 200:
+                response_data = response.data.decode("utf-8")
+                endpoint_map = json.loads(response_data)
+                with self._mutex:
+                    self._bolt_endpoints = defaultdict(list, endpoint_map)
         except Exception as e:
             raise e
 
     def _select_endpoint(self, method):
-        preferred_order = self.PREFERRED_READ_ENDPOINT_ORDER if method in {"GET", "HEAD"} else self.PREFERRED_WRITE_ENDPOINT_ORDER
-        
-        with self._mutex: 
+        preferred_order = (
+            self.PREFERRED_READ_ENDPOINT_ORDER
+            if method in {"GET", "HEAD"}
+            else self.PREFERRED_WRITE_ENDPOINT_ORDER
+        )
+
+        with self._mutex:
             for endpoints in preferred_order:
                 if self._bolt_endpoints[endpoints]:
                     # use random choice for load balancing
                     return choice(self._bolt_endpoints[endpoints])
         # if we reach this point, no endpoints are available
-        raise UnknownEndpointError(service_name='bolt', region_name=self._az_id)
-
+        raise UnknownEndpointError(service_name="bolt", region_name=self._az_id)

--- a/granica/bolt_router.py
+++ b/granica/bolt_router.py
@@ -1,28 +1,25 @@
-from collections import defaultdict
+import copy
+import datetime
 import json
+import random
+import sched
+import string
+import sys
+import time
+from collections import defaultdict
+from functools import wraps
 from os import environ
 from random import choice
+from threading import Lock, Thread
 from urllib.parse import urlsplit, urlunsplit
+
+from botocore.auth import SIGV4_TIMESTAMP, SigV4Auth, logger
+from botocore.awsrequest import AWSRequest
+from botocore.exceptions import NoCredentialsError, UnknownEndpointError
+from botocore.httpsession import URLLib3Session
+from botocore.session import get_session
 from urllib3 import PoolManager
 from urllib3.util.retry import Retry
-from threading import Lock
-
-import copy
-import random
-import sys
-import sched
-import time
-import datetime
-import string
-from functools import wraps
-from threading import Thread
-
-
-from botocore.auth import SigV4Auth, SIGV4_TIMESTAMP, logger
-from botocore.awsrequest import AWSRequest
-from botocore.exceptions import UnknownEndpointError, NoCredentialsError
-from botocore.session import get_session
-from botocore.httpsession import URLLib3Session
 
 EC2_INSTANCE_METADATA_API_BASE_URL = "http://169.254.169.254"
 

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(
         "Topic :: Software Development :: Libraries",
     ],
     python_requires=python_requires,
-    url="https://gitlab.com/projectn-oss/projectn-bolt-python",
+    url="https://github.com/project-n-oss/projectn-bolt-python",
 )

--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,21 @@
 import setuptools
 from setuptools import setup
 
-requires = ['boto3', 'botocore']
-python_requires = '>=3'
+requires = ["boto3", "botocore"]
+python_requires = ">=3"
 
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    name='granica-sdk',
+    name="granica-sdk",
     packages=setuptools.find_packages(),
-    version='2.1.9',
-    description='Granica Python SDK',
+    version="2.2.0",
+    description="Granica Python SDK",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    author='Project N',
+    long_description_content_type="text/markdown",
+    author="Project N",
     install_requires=requires,
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR is a backport of the changes I made to the py2 sdk a while back

* fix metadata api interaction by adding auth - region and az id can now be deduced if not provided via env vars
* only update quicksilver endpoints if query to quicksilver returned 200 response code
* use a shared http pool
* set endpoint update frequency to 10 seconds to be consistent with other sdks & sidekick
* update readme w/ granica env vars & for clarity
* implement backwards compatibility to support `BOLT_*` env vars
* version bump

**Testing**
Tested put object, list objects, get object against a live granica cluster