### PR TITLE
feat: single endpoint mode

### DIFF
--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -95,7 +95,7 @@ class Session(Boto3Session):
             self.bolt_router.single_endpoint_mode = single_endpoint_mode
 
             if single_endpoint_mode:
-                if kwargs.get("crunch_endpoint", False):
+                if not kwargs.get("crunch_endpoint", False):
                     raise ValueError(
                         "single_endpoint_mode is True but crunch_endpoint is not provided"
                     )

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -91,7 +91,6 @@ class Session(Boto3Session):
         if kwargs.get("service_name") == "s3" or "s3" in args:
             kwargs["config"] = self._merge_bolt_config(kwargs.get("config"))
             single_endpoint_mode = kwargs.get("single_endpoint_mode", False)
-            kwargs.pop("single_endpoint_mode", None)
             self.bolt_router.single_endpoint_mode = single_endpoint_mode
 
             if single_endpoint_mode:
@@ -101,6 +100,9 @@ class Session(Boto3Session):
                     )
                 else:
                     self.bolt_router.crunch_endpoint = kwargs.get("crunch_endpoint")
+
+            kwargs.pop("single_endpoint_mode", None)
+            kwargs.pop("crunch_endpoint", None)
 
             return self._session.create_client(*args, **kwargs)
         else:

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -94,6 +94,14 @@ class Session(Boto3Session):
             kwargs.pop("single_endpoint_mode", None)
             self.bolt_router.single_endpoint_mode = single_endpoint_mode
 
+            if single_endpoint_mode:
+                if kwargs.get("crunch_endpoint", False):
+                    raise ValueError(
+                        "single_endpoint_mode is True but crunch_endpoint is not provided"
+                    )
+                else:
+                    self.bolt_router.crunch_endpoint = kwargs.get("crunch_endpoint")
+
             return self._session.create_client(*args, **kwargs)
         else:
             return self._session.create_client(*args, **kwargs)

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -91,6 +91,7 @@ class Session(Boto3Session):
         kwargs.get("single_endpoint_mode")
         print("single endpoint mode:")
         print(kwargs.get("single_endpoint_mode"))
+        kwargs.pop("single_endpoint_mode")
         if kwargs.get("service_name") == "s3" or "s3" in args:
             kwargs["config"] = self._merge_bolt_config(kwargs.get("config"))
             return self._session.create_client(*args, **kwargs)

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -22,7 +22,7 @@ BOLT_ENDPOINT_UPDATE_INTERVAL = 10
 
 # Override Session Class
 class Session(Boto3Session):
-    def __init__(self):
+    def __init__(self, single_endpoint_mode=False):
         super(Session, self).__init__()
 
         custom_domain = environ.get("GRANICA_CUSTOM_DOMAIN")

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -91,7 +91,6 @@ class Session(Boto3Session):
         if kwargs.get("service_name") == "s3" or "s3" in args:
             kwargs["config"] = self._merge_bolt_config(kwargs.get("config"))
             single_endpoint_mode = kwargs.get("single_endpoint_mode", False)
-            kwargs["config"]["single_endpoint_mode"] = single_endpoint_mode
             kwargs.pop("single_endpoint_mode", None)
             self.bolt_router.single_endpoint_mode = single_endpoint_mode
 

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -88,6 +88,9 @@ class Session(Boto3Session):
         self.events.register_last("before-send.s3", self.bolt_router.send)
 
     def client(self, *args, **kwargs):
+        kwargs.get("single_endpoint_mode")
+        print("single endpoint mode:")
+        print(kwargs.get("single_endpoint_mode")
         if kwargs.get("service_name") == "s3" or "s3" in args:
             kwargs["config"] = self._merge_bolt_config(kwargs.get("config"))
             return self._session.create_client(*args, **kwargs)

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -90,7 +90,7 @@ class Session(Boto3Session):
     def client(self, *args, **kwargs):
         kwargs.get("single_endpoint_mode")
         print("single endpoint mode:")
-        print(kwargs.get("single_endpoint_mode")
+        print(kwargs.get("single_endpoint_mode"))
         if kwargs.get("service_name") == "s3" or "s3" in args:
             kwargs["config"] = self._merge_bolt_config(kwargs.get("config"))
             return self._session.create_client(*args, **kwargs)

--- a/granica/__init__.py
+++ b/granica/__init__.py
@@ -88,12 +88,13 @@ class Session(Boto3Session):
         self.events.register_last("before-send.s3", self.bolt_router.send)
 
     def client(self, *args, **kwargs):
-        kwargs.get("single_endpoint_mode")
-        print("single endpoint mode:")
-        print(kwargs.get("single_endpoint_mode"))
-        kwargs.pop("single_endpoint_mode")
         if kwargs.get("service_name") == "s3" or "s3" in args:
             kwargs["config"] = self._merge_bolt_config(kwargs.get("config"))
+            single_endpoint_mode = kwargs.get("single_endpoint_mode", False)
+            kwargs["config"]["single_endpoint_mode"] = single_endpoint_mode
+            kwargs.pop("single_endpoint_mode", None)
+            self.bolt_router.single_endpoint_mode = single_endpoint_mode
+
             return self._session.create_client(*args, **kwargs)
         else:
             return self._session.create_client(*args, **kwargs)

--- a/granica/bolt_router.py
+++ b/granica/bolt_router.py
@@ -265,6 +265,8 @@ class BoltRouter:
             for _ in range(4)
         )
 
+        self.single_endpoint_mode = False
+
         if update_interval > 0:
 
             @async_function
@@ -279,6 +281,7 @@ class BoltRouter:
 
     def send(self, *args, **kwargs):
         # Dispatches to the configured Bolt scheme and host.
+        print("SINGLE ENDPOINT MODE: {}".format(self.single_endpoint_mode))
         prepared_request = kwargs["request"]
         incoming_request = copy.deepcopy(prepared_request)
         _, _, path, query, fragment = urlsplit(prepared_request.url)

--- a/granica/bolt_router.py
+++ b/granica/bolt_router.py
@@ -266,6 +266,7 @@ class BoltRouter:
         )
 
         self.single_endpoint_mode = False
+        self.crunch_endpoint = None
 
         if update_interval > 0:
 
@@ -281,7 +282,6 @@ class BoltRouter:
 
     def send(self, *args, **kwargs):
         # Dispatches to the configured Bolt scheme and host.
-        print("SINGLE ENDPOINT MODE: {}".format(self.single_endpoint_mode))
         prepared_request = kwargs["request"]
         incoming_request = copy.deepcopy(prepared_request)
         _, _, path, query, fragment = urlsplit(prepared_request.url)
@@ -357,6 +357,9 @@ class BoltRouter:
             raise e
 
     def _select_endpoint(self, method):
+        if self.single_endpoint_mode:
+            return self.crunch_endpoint
+
         preferred_order = (
             self.PREFERRED_READ_ENDPOINT_ORDER
             if method in {"GET", "HEAD"}


### PR DESCRIPTION
This PR introduces a single endpoint mode to granica python sdk. In this way, the sdk can be pointed at a specific read replica endpoint via client constructor.

example
```python
import granica

bolt_s3_client = granica.client("s3", single_endpoint_mode=True, crunch_endpoint="https://10.196.142.109:443")
```